### PR TITLE
Fixed - mimeFormatLookup function mutating db on every call

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,12 +192,8 @@ module.exports = {
 
         // sanitise the mime argument
         mime = String(mime).toLowerCase().replace(/\s/g, E).replace(/^([^;]+).*$/g, '$1');
-        var result;
-        if(db[mime]){
-            result = {...db[mime]};
-        }else{
-            result = module.exports.guess(mime);
-        }
+        var result = db[mime];
+        result = result ? {...result} : module.exports.guess(mime)
         // add the charset info to the mime.
         result && charset && (result.charset = charset);
         result && (result.source = mime); // store the sanitised mime

--- a/index.js
+++ b/index.js
@@ -193,7 +193,8 @@ module.exports = {
         // sanitise the mime argument
         mime = String(mime).toLowerCase().replace(/\s/g, E).replace(/^([^;]+).*$/g, '$1');
         var result = db[mime];
-        result = result ? {...result} : module.exports.guess(mime)
+        result = result ? {...result} : module.exports.guess(mime);
+
         // add the charset info to the mime.
         result && charset && (result.charset = charset);
         result && (result.source = mime); // store the sanitised mime

--- a/index.js
+++ b/index.js
@@ -192,8 +192,12 @@ module.exports = {
 
         // sanitise the mime argument
         mime = String(mime).toLowerCase().replace(/\s/g, E).replace(/^([^;]+).*$/g, '$1');
-        var result = db[mime] || module.exports.guess(mime);
-
+        var result;
+        if(db[mime]){
+            result = {...db[mime]};
+        }else{
+            result = module.exports.guess(mime);
+        }
         // add the charset info to the mime.
         result && charset && (result.charset = charset);
         result && (result.source = mime); // store the sanitised mime

--- a/unit-test.spec.js
+++ b/unit-test.spec.js
@@ -512,6 +512,8 @@ describe('lookup', function () {
     });
 
     describe("Regression", function () {
+
+        // Github issue: https://github.com/postmanlabs/postman-app-support/issues/8876
         it("charset provided in a call should not persist in subsequent calls without charset", function () {
             var mime = mimeFormat.lookup('application/json; charset=utf-16');
             expect(mime).have.property('type', 'text');

--- a/unit-test.spec.js
+++ b/unit-test.spec.js
@@ -500,18 +500,6 @@ describe('lookup', function () {
     });
 
     describe("Charset won't be available if it is not mentioned", function () {
-        it("After an explicit charset", function () {
-            var mime = mimeFormat.lookup('application/json; charset=utf-16');
-            expect(mime).have.property('type', 'text');
-            expect(mime).have.property('format', 'json');
-            expect(mime).have.property('charset', 'utf-16');
-
-            mime = mimeFormat.lookup('application/json');
-            expect(mime).have.property('type', 'text');
-            expect(mime).have.property('format', 'json');
-            expect(mime).not.have.property('charset');
-        });
-
         it("text/html", function() {
             var mime = mimeFormat.lookup('text/html;');
             expect(mime).not.have.property('charset');
@@ -522,4 +510,18 @@ describe('lookup', function () {
             expect(mime).not.have.property('charset');
         });
     });
+
+    describe("Regression", function () {
+        it("charset provided in a call should not persist in subsequent calls without charset", function () {
+            var mime = mimeFormat.lookup('application/json; charset=utf-16');
+            expect(mime).have.property('type', 'text');
+            expect(mime).have.property('format', 'json');
+            expect(mime).have.property('charset', 'utf-16');
+
+            mime = mimeFormat.lookup('application/json');
+            expect(mime).have.property('type', 'text');
+            expect(mime).have.property('format', 'json');
+            expect(mime).not.have.property('charset');
+        });
+    })
 });

--- a/unit-test.spec.js
+++ b/unit-test.spec.js
@@ -500,6 +500,18 @@ describe('lookup', function () {
     });
 
     describe("Charset won't be available if it is not mentioned", function () {
+        it("After an explicit charset", function () {
+            var mime = mimeFormat.lookup('application/json; charset=utf-16');
+            expect(mime).have.property('type', 'text');
+            expect(mime).have.property('format', 'json');
+            expect(mime).have.property('charset', 'utf-16');
+
+            mime = mimeFormat.lookup('application/json');
+            expect(mime).have.property('type', 'text');
+            expect(mime).have.property('format', 'json');
+            expect(mime).not.have.property('charset');
+        });
+
         it("text/html", function() {
             var mime = mimeFormat.lookup('text/html;');
             expect(mime).not.have.property('charset');


### PR DESCRIPTION
Earlier the function was mutating the original db since it was using a reference to the object. Changed it to clone the object before mutating.